### PR TITLE
fix the output table format

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: ktplots
 Title: Plot single-cell data dotplots
-Version: 1.2.4
+Version: 1.2.5
 Authors@R: person("Kelvin", "Tuong", email = c("z.tuong@uq.edu.au"), role = c("aut", "cre"))
 Description: Plotting tools for scData.
 License: MIT

--- a/R/plot_cpdb_heatmap.R
+++ b/R/plot_cpdb_heatmap.R
@@ -104,6 +104,7 @@ plot_cpdb_heatmap <- function(
       count_mat <- count_mat + t(count_mat)
       diag(count_mat) <- dcm
     }
+    
     if (log1p_transform) {
       count_mat <- log1p(count_mat)
     }
@@ -125,7 +126,7 @@ plot_cpdb_heatmap <- function(
         row_sum <- rowSums(count_mat)
         col_sum <- colSums(count_mat)
         all_sum <- data.frame(row_sum, col_sum)
-        return(list(count_network = t(count_mat), interaction_count = all_sum))
+        return(list(count_network = count_mat, interaction_count = all_sum))
       }
     } else {
       return(p)

--- a/R/plot_cpdb_heatmap.R
+++ b/R/plot_cpdb_heatmap.R
@@ -31,23 +31,25 @@
 #' \donttest{
 #' data(kidneyimmune)
 #' data(cpdb_output2)
-#' plot_cpdb_heatmap(kidneyimmune, 'celltype', pvals2)
+#' plot_cpdb_heatmap(kidneyimmune, "celltype", pvals2)
 #' }
 #' @import pheatmap
 #' @export
 
-plot_cpdb_heatmap <- function(scdata, idents, pvals, log1p_transform = FALSE, show_rownames = TRUE,
-  show_colnames = TRUE, scale = "none", cluster_cols = TRUE, cluster_rows = TRUE,
-  border_color = "white", fontsize_row = 11, fontsize_col = 11, family = "Arial",
-  main = "", treeheight_col = 0, treeheight_row = 0, low_col = "dodgerblue4", mid_col = "peachpuff",
-  high_col = "deeppink4", alpha = 0.05, return_tables = FALSE, degs_analysis = FALSE,
-  verbose = FALSE, symmetrical = TRUE, ...) {
+plot_cpdb_heatmap <- function(
+    scdata, idents, pvals, log1p_transform = FALSE, show_rownames = TRUE,
+    show_colnames = TRUE, scale = "none", cluster_cols = TRUE, cluster_rows = TRUE,
+    border_color = "white", fontsize_row = 11, fontsize_col = 11, family = "Arial",
+    main = "", treeheight_col = 0, treeheight_row = 0, low_col = "dodgerblue4", mid_col = "peachpuff",
+    high_col = "deeppink4", alpha = 0.05, return_tables = FALSE, degs_analysis = FALSE,
+    verbose = FALSE, symmetrical = TRUE, ...) {
   requireNamespace("reshape2")
   requireNamespace("grDevices")
   if (class(scdata) %in% c("SingleCellExperiment", "SummarizedExperiment")) {
     if (verbose) {
       cat("data provided is a SingleCellExperiment/SummarizedExperiment object",
-        sep = "\n")
+        sep = "\n"
+      )
       cat("extracting expression matrix", sep = "\n")
     }
     requireNamespace("SummarizedExperiment")
@@ -96,9 +98,6 @@ plot_cpdb_heatmap <- function(scdata, idents, pvals, log1p_transform = FALSE, sh
   if (any(all_count$COUNT) > 0) {
     count_mat <- reshape2::acast(SOURCE ~ TARGET, data = all_count, value.var = "COUNT")
     count_mat[is.na(count_mat)] <- 0
-
-    all_sum <- rowSums(count_mat)
-    all_sum <- cbind(names(all_sum), all_sum)
     col.heatmap <- (grDevices::colorRampPalette(c(low_col, mid_col, high_col)))(1000)
     if (symmetrical) {
       dcm <- diag(count_mat)
@@ -109,13 +108,25 @@ plot_cpdb_heatmap <- function(scdata, idents, pvals, log1p_transform = FALSE, sh
       count_mat <- log1p(count_mat)
     }
 
-    p <- pheatmap(count_mat, show_rownames = show_rownames, show_colnames = show_colnames,
+    p <- pheatmap(count_mat,
+      show_rownames = show_rownames, show_colnames = show_colnames,
       scale = scale, cluster_cols = cluster_cols, border_color = border_color,
       cluster_rows = cluster_rows, fontsize_row = fontsize_row, fontsize_col = fontsize_col,
       main = main, treeheight_row = treeheight_row, family = family, color = col.heatmap,
-      treeheight_col = treeheight_col, ...)
+      treeheight_col = treeheight_col, ...
+    )
     if (return_tables) {
-      return(list(count_network = count_mat, interaction_count = all_sum))
+      if (symmetrical) {
+        all_sum <- rowSums(count_mat)
+        all_sum <- data.frame(all_sum)
+        return(list(count_network = count_mat, interaction_count = all_sum))
+      } else {
+        count_mat <- t(count_mat) # so that the table output is the same layout as the plot
+        row_sum <- rowSums(count_mat)
+        col_sum <- colSums(count_mat)
+        all_sum <- data.frame(row_sum, col_sum)
+        return(list(count_network = t(count_mat), interaction_count = all_sum))
+      }
     } else {
       return(p)
     }

--- a/README.md
+++ b/README.md
@@ -325,23 +325,7 @@ plot_cpdb4(
 
 ## plot_cpdb_heatmap
 
-New! Ported the original heatmap plot to this pacakge as per the main cellphonedb repo. Uses `pheatmap` internally. Colours indicate the number of significant interactions. The values for the `symmetrical=False` mode follow the direction of the L-R direction where it's always moleculeA:celltypeA -> moleculeB:celltypeB. For example,
- 
- - x axis -> y axis:
-    
-    A: MNPc(DC)
-    
-    B: NK cell 
-    
-    A -> B is 22 interactions
- - y axis -> x axis:
-   
-    
-    A: NK cell
-    
-    B: MNPc(DC)
-    
-    A -> B is 20 interactions
+Ported the original heatmap plot to this pacakge as per the main cellphonedb repo. Uses `pheatmap` internally. Colours indicate the number of significant interactions. 
 
 ```R
 plot_cpdb_heatmap(kidneyimmune, 'celltype', pvals2, cellheight = 10, cellwidth = 10)
@@ -354,6 +338,18 @@ plot_cpdb_heatmap(kidneyimmune, 'celltype', pvals2, cellheight = 10, cellwidth =
 ```
 
 ![plot_cpdb_heatmap](exampleImages/plot_cpdb_heatmap.png)
+
+The values for the `symmetrical=FALSE` mode follow the direction of the L-R direction where it's always moleculeA:celltypeA -> moleculeB:celltypeB.
+
+Therefore, if you trace on the `x-axis` for `celltype A` [MNPa(mono)] to `celltype B` [CD8T cell] on the `y-axis`:
+
+A -> B is 18 interactions
+
+Whereas if you trace on the `y-axis` for `celltype A` [MNPa(mono)] to `celltype B` [CD8T cell] on the `x-axis`:
+
+A -> B is 9 interactions
+
+`symmetrical=TRUE` mode will return 18+9 = 27
 
 ## Other useful functions
 

--- a/man/plot_cpdb_heatmap.Rd
+++ b/man/plot_cpdb_heatmap.Rd
@@ -93,6 +93,6 @@ Plotting cellphonedb results as a heatmap
 \donttest{
 data(kidneyimmune)
 data(cpdb_output2)
-plot_cpdb_heatmap(kidneyimmune, 'celltype', pvals2)
+plot_cpdb_heatmap(kidneyimmune, "celltype", pvals2)
 }
 }


### PR DESCRIPTION
So now the output table in `return_tables=T` gives the same layout as per the plot, particularly for `symmetrical=F` situation. Also rearranged the construction of the `interaction_count` output to be consistent with the options.